### PR TITLE
Set up a working debug configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,8 @@ ipch/
 *.sdf
 *.cachefile
 win.vs2015/LabSound.VC.*
+labsound/win.vs2017/.vs
+labsound/win.vs2017/PredictedInputCache*.dat
 
 # Visual Studio profiler
 *.psess

--- a/binding.gyp
+++ b/binding.gyp
@@ -35,32 +35,54 @@
             '-Wl,-Bsymbolic',
           ],
         }],
-        ['OS=="win"', {
-          'library_dirs': [
-            '<(module_root_dir)/labsound/build/x64/Release',
+      ['OS=="win"', {
+        'configurations': {
+          'Debug': {
+            'msvs_settings': {
+              'VCCLCompilerTool': {
+                'RuntimeLibrary': '3' # /MDd
+              },
+            },
+            'library_dirs': [
+              '<(module_root_dir)/labsound/build/x64/Debug',
             "<!(node -e \"console.log(require.resolve('native-video-deps').slice(0, -9) + '/lib/win')\")",
-          ],
-          'libraries': [
-            'LabSound.lib',
-            'avformat.lib',
-            'avcodec.lib',
-            'avutil.lib',
-            'swscale.lib',
-            'swresample.lib',
-          ],
-          'copies': [
-            {
-              'destination': '<(module_root_dir)/build/Release/',
-              'files': [
-                "<!(node -e \"console.log(require.resolve('native-video-deps').slice(0, -9) + '/lib/win/avformat-58.dll')\")",
-                "<!(node -e \"console.log(require.resolve('native-video-deps').slice(0, -9) + '/lib/win/avcodec-58.dll')\")",
-                "<!(node -e \"console.log(require.resolve('native-video-deps').slice(0, -9) + '/lib/win/avutil-56.dll')\")",
-                "<!(node -e \"console.log(require.resolve('native-video-deps').slice(0, -9) + '/lib/win/swscale-5.dll')\")",
-                "<!(node -e \"console.log(require.resolve('native-video-deps').slice(0, -9) + '/lib/win/swresample-3.dll')\")",
-              ]
-            }
-          ],
+            ],
+          },
+          'Release': {
+            'library_dirs': [
+              '<(module_root_dir)/labsound/build/x64/Release',
+            "<!(node -e \"console.log(require.resolve('native-video-deps').slice(0, -9) + '/lib/win')\")",
+            ],
+          },
+        },
+        'copies': [{
+          'destination': '<(module_root_dir)/build/Debug/',
+          'files': [
+            "<!(node -e \"console.log(require.resolve('native-video-deps').slice(0, -9) + '/lib/win/avformat-58.dll')\")",
+          "<!(node -e \"console.log(require.resolve('native-video-deps').slice(0, -9) + '/lib/win/avcodec-58.dll')\")",
+          "<!(node -e \"console.log(require.resolve('native-video-deps').slice(0, -9) + '/lib/win/avutil-56.dll')\")",
+          "<!(node -e \"console.log(require.resolve('native-video-deps').slice(0, -9) + '/lib/win/swscale-5.dll')\")",
+          "<!(node -e \"console.log(require.resolve('native-video-deps').slice(0, -9) + '/lib/win/swresample-3.dll')\")",
+          ]
+        }, {
+          'destination': '<(module_root_dir)/build/Release/',
+          'files': [
+            "<!(node -e \"console.log(require.resolve('native-video-deps').slice(0, -9) + '/lib/win/avformat-58.dll')\")",
+          "<!(node -e \"console.log(require.resolve('native-video-deps').slice(0, -9) + '/lib/win/avcodec-58.dll')\")",
+          "<!(node -e \"console.log(require.resolve('native-video-deps').slice(0, -9) + '/lib/win/avutil-56.dll')\")",
+          "<!(node -e \"console.log(require.resolve('native-video-deps').slice(0, -9) + '/lib/win/swscale-5.dll')\")",
+          "<!(node -e \"console.log(require.resolve('native-video-deps').slice(0, -9) + '/lib/win/swresample-3.dll')\")",
+          ]
         }],
+        'libraries': [
+          'LabSound.lib',
+        'avformat.lib',
+        'avcodec.lib',
+        'avutil.lib',
+        'swscale.lib',
+        'swresample.lib',
+        ],
+      }],
         ['OS=="mac"', {
         'library_dirs': [
             '<(module_root_dir)/labsound/bin',

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const path = require('path');
-const bindings = require('./build/Release/webaudio.node');
-// const bindings = require('./build/Debug/webaudio.node');
+const configuration = process.env.LABSOUND_DEBUG ? 'Debug' : 'Release';
+const bindings = require(`./build/${configuration}/webaudio.node`)
 
 const {PannerNode} = bindings;
 PannerNode.setPath(path.join(__dirname, 'labsound', 'assets', 'hrtf'));

--- a/labsound/build-windows-debug.cmd
+++ b/labsound/build-windows-debug.cmd
@@ -1,0 +1,1 @@
+msbuild .\win.vs2017\LabSound.sln /p:Configuration=Debug /p:Platform=x64 /t:Clean,Build

--- a/labsound/win.vs2017/LabSound.vcxproj
+++ b/labsound/win.vs2017/LabSound.vcxproj
@@ -961,10 +961,10 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(ProjectDir)..\include;$(ProjectDir)..\src;$(ProjectDir)..\third_party;$(ProjectDir)..\third_party\STK;$(ProjectDir)..\..\node_modules\native-video-deps\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>DEBUG;_ITERATOR_DEBUG_LEVEL=0;STATICALLY_LINKED_WITH_WTF;WIN32;D_VARIADIC_MAX=10;D_NOMINMAX;NOMINMAX;WTF_USE_WEBAUDIO_KISSFFT=1;__WINDOWS_WASAPI__;HAVE_NO_OFLOG;HAVE_BOOST_THREAD;HAVE_LIBDL;HAVE_ALLOCA;HAVE_UNISTD_H;__OS_WINDOWS__;__LITTLE_ENDIAN__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>DEBUG;STATICALLY_LINKED_WITH_WTF;WIN32;D_VARIADIC_MAX=10;D_NOMINMAX;NOMINMAX;WTF_USE_WEBAUDIO_KISSFFT=1;__WINDOWS_WASAPI__;HAVE_NO_OFLOG;HAVE_BOOST_THREAD;HAVE_LIBDL;HAVE_ALLOCA;HAVE_UNISTD_H;__OS_WINDOWS__;__LITTLE_ENDIAN__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>
@@ -995,9 +995,9 @@
     <ClCompile>
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>$(ProjectDir)..\include;$(ProjectDir)..\src;$(ProjectDir)..\third_party;$(ProjectDir)..\third_party\STK;$(ProjectDir)..\..\node_modules\native-video-deps\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>DEBUG;_ITERATOR_DEBUG_LEVEL=0;STATICALLY_LINKED_WITH_WTF;WIN32;D_VARIADIC_MAX=10;D_NOMINMAX;NOMINMAX;WTF_USE_WEBAUDIO_KISSFFT=1;__WINDOWS_WASAPI__;HAVE_NO_OFLOG;HAVE_BOOST_THREAD;HAVE_LIBDL;HAVE_ALLOCA;HAVE_UNISTD_H;__OS_WINDOWS__;__LITTLE_ENDIAN__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>DEBUG;STATICALLY_LINKED_WITH_WTF;WIN32;D_VARIADIC_MAX=10;D_NOMINMAX;NOMINMAX;WTF_USE_WEBAUDIO_KISSFFT=1;__WINDOWS_WASAPI__;HAVE_NO_OFLOG;HAVE_BOOST_THREAD;HAVE_LIBDL;HAVE_ALLOCA;HAVE_UNISTD_H;__OS_WINDOWS__;__LITTLE_ENDIAN__;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PrecompiledHeader>
       </PrecompiledHeader>


### PR DESCRIPTION
This PR adds the ability to step through LabSound in Visual Studio's debugger.

To do this, I run `build-windows-debug` using MSBuild command prompt, then I run `node-gyp-debug`, which is a custom script in my PATH:

```
CALL node-gyp configure rebuild --nodedir="B:\node" --debug %*
```

`B:\node` is where I ran `.\vcbuild debug x64 openssl-no-asm` to build the latest Node master branch from source.

At that point, you can successfully use VS's debugger! And you can even see the stack trace all the way to the bottom of Node.

I was going to continue pushing the sample rate fixes, but this seemed like a good spot to submit a PR.