### PR TITLE
Move FinishableSourceNode callbacks to main thread

### DIFF
--- a/labsound/include/LabSound/core/AudioContext.h
+++ b/labsound/include/LabSound/core/AudioContext.h
@@ -103,6 +103,10 @@ public:
     
     // Necessary to call when using an OfflineAudioDestinationNode
     void startRendering();
+
+    void queueInMainThread(std::function<void()> &&finishedCallback);
+    void runInMainThread();
+
     std::function<void()> offlineRenderCompleteCallback;
 
 private:

--- a/labsound/include/LabSound/core/FinishableSourceNode.h
+++ b/labsound/include/LabSound/core/FinishableSourceNode.h
@@ -13,12 +13,12 @@ namespace lab {
 
 class FinishableSourceNode : public SampledAudioNode {
 public:
-  FinishableSourceNode(std::function<void(ContextRenderLock &r)> &&finishedCallback);
+  FinishableSourceNode(std::function<void()> &&finishedCallback);
   ~FinishableSourceNode();
 protected:
   virtual void finish(ContextRenderLock &r);
 
-  std::function<void(ContextRenderLock &r)> finishedCallback;
+  std::function<void()> finishedCallback;
 };
 
 } // namespace lab

--- a/labsound/src/core/AudioContext.cpp
+++ b/labsound/src/core/AudioContext.cpp
@@ -20,8 +20,13 @@
 #include <queue>
 #include <assert.h>
 
+struct msg_t {
+    std::__1::function<void ()> task;
+};
+
 namespace lab
 {
+concurrent_queue<msg_t> callbacks;
 
 const uint32_t lab::AudioContext::maxNumberOfChannels = 32;
 
@@ -435,6 +440,19 @@ unsigned long AudioContext::activeSourceCount() const
 void AudioContext::startRendering()
 {
     destination()->startRendering();
+}
+
+void AudioContext::queueInMainThread(std::function<void()> &&finishedCallback) {
+    msg_t msg;
+    msg.task = std::move(finishedCallback);
+    callbacks.push(msg);
+}
+
+void AudioContext::runInMainThread() {
+    msg_t msg;
+    while (callbacks.try_pop(msg)) {
+        msg.task();
+    }
 }
 
 void AudioContext::incrementActiveSourceCount()

--- a/labsound/src/core/AudioContext.cpp
+++ b/labsound/src/core/AudioContext.cpp
@@ -21,7 +21,7 @@
 #include <assert.h>
 
 struct msg_t {
-    std::__1::function<void ()> task;
+    std::function<void ()> task;
 };
 
 namespace lab

--- a/labsound/src/core/FinishableSourceNode.cpp
+++ b/labsound/src/core/FinishableSourceNode.cpp
@@ -6,16 +6,18 @@
 // @tofix - webkit change e369924 adds backward playback, change not incorporated yet
 
 #include "LabSound/core/FinishableSourceNode.h"
+#include "LabSound/extended/AudioContextLock.h"
 
 using namespace std;
 
 namespace lab {
 
-FinishableSourceNode::FinishableSourceNode(std::function<void(ContextRenderLock &r)> &&finishedCallback) : finishedCallback(std::move(finishedCallback)) {}
+FinishableSourceNode::FinishableSourceNode(std::function<void()> &&finishedCallback)
+: finishedCallback(std::move(finishedCallback)) {}
 FinishableSourceNode::~FinishableSourceNode() {}
 void FinishableSourceNode::finish(ContextRenderLock &r) {
   SampledAudioNode::finish(r);
-  finishedCallback(r);
+  r.context()->queueInMainThread(std::move(finishedCallback));
 }
 
 } // namespace lab


### PR DESCRIPTION
Note that this requires the user to call
AudioContext::runInMainThread() periodically.