### PR TITLE
Reentrant start/stop for AudioScheduledSourceNode

### DIFF
--- a/labsound/src/core/AudioScheduledSourceNode.cpp
+++ b/labsound/src/core/AudioScheduledSourceNode.cpp
@@ -57,7 +57,7 @@ void AudioScheduledSourceNode::updateSchedulingInfo(ContextRenderLock& r,
     if (m_endTime != UnknownTime && endFrame <= quantumStartFrame)
         finish(r);
 
-    if (m_playbackState == UNSCHEDULED_STATE || m_playbackState == FINISHED_STATE || startFrame >= quantumEndFrame) {
+    if (m_playbackState == UNSCHEDULED_STATE || startFrame >= quantumEndFrame) {
         // Output silence.
         outputBus->zero();
         nonSilentFramesToProcess = 0;
@@ -138,7 +138,7 @@ void AudioScheduledSourceNode::stop(double when)
 
 void AudioScheduledSourceNode::finish(ContextRenderLock& r)
 {
-    m_playbackState = FINISHED_STATE;
+    m_playbackState = UNSCHEDULED_STATE;
     r.context()->decrementActiveSourceCount();
 }
 

--- a/labsound/src/core/AudioScheduledSourceNode.cpp
+++ b/labsound/src/core/AudioScheduledSourceNode.cpp
@@ -119,9 +119,6 @@ void AudioScheduledSourceNode::updateSchedulingInfo(ContextRenderLock& r,
 
 void AudioScheduledSourceNode::start(double when)
 {
-    if (m_playbackState != UNSCHEDULED_STATE)
-        return;
-
     if (!std::isfinite(when) || (when < 0)) {
         return;
     }
@@ -132,12 +129,9 @@ void AudioScheduledSourceNode::start(double when)
 
 void AudioScheduledSourceNode::stop(double when)
 {
-    if (!(m_playbackState == SCHEDULED_STATE || m_playbackState == PLAYING_STATE))
-        return;
-    
     if (!std::isfinite(when))
         return;
-    
+
     when = max(0.0, when);
     m_endTime = when;
 }

--- a/labsound/src/core/AudioScheduledSourceNode.cpp
+++ b/labsound/src/core/AudioScheduledSourceNode.cpp
@@ -124,7 +124,11 @@ void AudioScheduledSourceNode::start(double when)
     }
 
     m_startTime = when;
-    m_playbackState = SCHEDULED_STATE;
+    m_endTime = UnknownTime;
+    
+    if (m_playbackState == UNSCHEDULED_STATE) {
+      m_playbackState = SCHEDULED_STATE;
+    }
 }
 
 void AudioScheduledSourceNode::stop(double when)


### PR DESCRIPTION
This allows `AudioScheduledSourceNode` to be restarted when it finishes, which is a lot closer to how **WebAudio** is supposed to work.