### PR TITLE
Add AudioContext suspend/resume

### DIFF
--- a/labsound/include/LabSound/core/AudioContext.h
+++ b/labsound/include/LabSound/core/AudioContext.h
@@ -100,6 +100,9 @@ public:
     void connectParam(std::shared_ptr<AudioParam> param, std::shared_ptr<AudioNode> driver, uint32_t index);
 
     void holdSourceNodeUntilFinished(std::shared_ptr<AudioScheduledSourceNode> node);
+
+    void suspend();
+    void resume();
     
     // Necessary to call when using an OfflineAudioDestinationNode
     void startRendering();

--- a/labsound/include/LabSound/core/AudioDestinationNode.h
+++ b/labsound/include/LabSound/core/AudioDestinationNode.h
@@ -37,6 +37,8 @@ public:
 
     size_t currentSampleFrame() const { return m_currentSampleFrame; }
     double currentTime() const;
+    virtual void suspend() {}
+    virtual void resume() {}
 
     virtual unsigned numberOfChannels() const { return 2; } // FIXME: update when multi-channel (more than stereo) is supported
 

--- a/labsound/src/core/AudioContext.cpp
+++ b/labsound/src/core/AudioContext.cpp
@@ -129,6 +129,14 @@ void AudioContext::holdSourceNodeUntilFinished(std::shared_ptr<AudioScheduledSou
     automaticSources.push_back(node);
 }
 
+void AudioContext::suspend() {
+  m_destinationNode->suspend();
+}
+
+void AudioContext::resume() {
+  m_destinationNode->resume();
+}
+
 void AudioContext::handleAutomaticSources()
 {
     std::lock_guard<std::mutex> lock(m_updateMutex);

--- a/labsound/src/internal/src/linux/AudioDestinationLinux.cpp
+++ b/labsound/src/internal/src/linux/AudioDestinationLinux.cpp
@@ -29,6 +29,7 @@ AudioDestinationLinux::AudioDestinationLinux(AudioIOCallback & callback, float s
 {
     m_sampleRate = sampleRate;
     m_renderBus.setSampleRate(m_sampleRate);
+    m_inputBus.setSampleRate(m_sampleRate);
     dac.reset(new RtAudio()); // XXX
     configure();
 }

--- a/labsound/src/internal/src/linux/AudioDestinationLinux.cpp
+++ b/labsound/src/internal/src/linux/AudioDestinationLinux.cpp
@@ -36,9 +36,9 @@ AudioDestinationLinux::AudioDestinationLinux(AudioIOCallback & callback, float s
 
 AudioDestinationLinux::~AudioDestinationLinux()
 {
-    dac.release(); // XXX
-    /* if (dac.isStreamOpen())
-        dac.closeStream(); */
+    // dac.release(); // XXX
+    if (dac.isStreamOpen())
+        dac.closeStream();
 }
 
 void AudioDestinationLinux::configure()
@@ -95,7 +95,7 @@ void AudioDestinationLinux::stop()
 {
     try
     {
-        // dac->stopStream(); // XXX
+        dac->stopStream();
         m_isPlaying = false;
     }
     catch (RtAudioError & e)

--- a/labsound/src/internal/src/linux/AudioDestinationLinux.cpp
+++ b/labsound/src/internal/src/linux/AudioDestinationLinux.cpp
@@ -37,8 +37,8 @@ AudioDestinationLinux::AudioDestinationLinux(AudioIOCallback & callback, float s
 AudioDestinationLinux::~AudioDestinationLinux()
 {
     // dac.release(); // XXX
-    if (dac.isStreamOpen())
-        dac.closeStream();
+    if (dac->isStreamOpen())
+        dac->closeStream();
 }
 
 void AudioDestinationLinux::configure()

--- a/labsound/src/internal/src/ml/AudioDestinationMl.cpp
+++ b/labsound/src/internal/src/ml/AudioDestinationMl.cpp
@@ -372,7 +372,7 @@ void AudioDestinationMl::render(int numberOfFrames, void *outputBuffer, void *in
     // Source Bus :: Destination Bus
     m_callback.render(&m_inputBus, &m_renderBus, numberOfFrames);
 
-    // Clamp values at 0d*b (i.e., [-1.0, 1.0])
+    // Clamp values at 0db (i.e., [-1.0, 1.0])
     for (unsigned i = 0; i < m_renderBus.numberOfChannels(); ++i)
     {
         AudioChannel * channel = m_renderBus.channel(i);

--- a/labsound/src/internal/src/ml/AudioDestinationMl.cpp
+++ b/labsound/src/internal/src/ml/AudioDestinationMl.cpp
@@ -330,6 +330,10 @@ void AudioDestinationMl::stop()
     } else {
       std::cerr << "failed to stop ml output sound: " << result << std::endl;
     }
+
+    if (isRecording()) {
+      stopRecording();
+    }
 }
 
 void AudioDestinationMl::startRecording()

--- a/labsound/src/internal/src/ml/AudioDestinationMl.cpp
+++ b/labsound/src/internal/src/ml/AudioDestinationMl.cpp
@@ -368,7 +368,7 @@ void AudioDestinationMl::render(int numberOfFrames, void *outputBuffer, void *in
     // Source Bus :: Destination Bus
     m_callback.render(&m_inputBus, &m_renderBus, numberOfFrames);
 
-    // Clamp values at 0db (i.e., [-1.0, 1.0])
+    // Clamp values at 0d*b (i.e., [-1.0, 1.0])
     for (unsigned i = 0; i < m_renderBus.numberOfChannels(); ++i)
     {
         AudioChannel * channel = m_renderBus.channel(i);

--- a/labsound/src/internal/src/win/AudioDestinationWin.cpp
+++ b/labsound/src/internal/src/win/AudioDestinationWin.cpp
@@ -29,6 +29,7 @@ AudioDestinationWin::AudioDestinationWin(AudioIOCallback & callback, float sampl
 {
     m_sampleRate = sampleRate;
     m_renderBus.setSampleRate(m_sampleRate);
+    m_inputBus.setSampleRate(m_sampleRate);
     dac.reset(new RtAudio()); // XXX
     configure();
 }

--- a/labsound/src/internal/src/win/AudioDestinationWin.cpp
+++ b/labsound/src/internal/src/win/AudioDestinationWin.cpp
@@ -37,8 +37,8 @@ AudioDestinationWin::AudioDestinationWin(AudioIOCallback & callback, float sampl
 AudioDestinationWin::~AudioDestinationWin()
 {
     // dac.release(); // XXX
-    if (dac.isStreamOpen())
-        dac.closeStream();
+    if (dac->isStreamOpen())
+        dac->closeStream();
 }
 
 void AudioDestinationWin::configure()

--- a/labsound/src/internal/src/win/AudioDestinationWin.cpp
+++ b/labsound/src/internal/src/win/AudioDestinationWin.cpp
@@ -36,9 +36,9 @@ AudioDestinationWin::AudioDestinationWin(AudioIOCallback & callback, float sampl
 
 AudioDestinationWin::~AudioDestinationWin()
 {
-    dac.release(); // XXX
-    /* if (dac.isStreamOpen())
-        dac.closeStream(); */
+    // dac.release(); // XXX
+    if (dac.isStreamOpen())
+        dac.closeStream();
 }
 
 void AudioDestinationWin::configure()
@@ -95,7 +95,7 @@ void AudioDestinationWin::stop()
 {
     try
     {
-        // dac->stopStream(); // XXX
+        dac->stopStream();
         m_isPlaying = false;
     }
     catch (RtAudioError & e)

--- a/labsound/third_party/rtaudio/src/RtAudio.cpp
+++ b/labsound/third_party/rtaudio/src/RtAudio.cpp
@@ -4331,9 +4331,20 @@ void RtApiWasapi::stopStream( void )
   // inform stream thread by setting stream state to STREAM_STOPPING
   stream_.state = STREAM_STOPPING;
 
+  HANDLE captureEvent = ( ( WasapiHandle* ) stream_.apiHandle )->captureEvent;
+  SetEvent(captureEvent);
+  
+  HANDLE renderEvent = ( ( WasapiHandle* ) stream_.apiHandle )->renderEvent;
+  SetEvent(renderEvent);
+  
   // wait until stream thread is stopped
   while( stream_.state != STREAM_STOPPED ) {
     Sleep( 1 );
+    
+    DWORD result = WaitForSingleObject( (HANDLE)stream_.callbackInfo.thread, 0);
+    if (result != WAIT_TIMEOUT) {
+      break;
+    }
   }
 
   // Wait for the last buffer to play before stopping.
@@ -4383,10 +4394,21 @@ void RtApiWasapi::abortStream( void )
 
   // inform stream thread by setting stream state to STREAM_STOPPING
   stream_.state = STREAM_STOPPING;
+  
+  HANDLE captureEvent = ( ( WasapiHandle* ) stream_.apiHandle )->captureEvent;
+  SetEvent(captureEvent);
+  
+  HANDLE renderEvent = ( ( WasapiHandle* ) stream_.apiHandle )->renderEvent;
+  SetEvent(renderEvent);
 
   // wait until stream thread is stopped
   while ( stream_.state != STREAM_STOPPED ) {
     Sleep( 1 );
+    
+    DWORD result = WaitForSingleObject( (HANDLE)stream_.callbackInfo.thread, 0);
+    if (result != WAIT_TIMEOUT) {
+      break;
+    }
   }
 
   // stop capture client if applicable

--- a/labsound/third_party/rtaudio/src/RtAudio.cpp
+++ b/labsound/third_party/rtaudio/src/RtAudio.cpp
@@ -5039,6 +5039,10 @@ void RtApiWasapi::wasapiThread()
       // if the callback input buffer was not pulled from captureBuffer, wait for next capture event
       if ( !callbackPulled ) {
         WaitForSingleObject( captureEvent, INFINITE );
+        
+        if (stream_.state == STREAM_STOPPING) {
+          break;
+        }
       }
 
       // Get capture buffer from stream
@@ -5095,6 +5099,10 @@ void RtApiWasapi::wasapiThread()
       // if the callback output buffer was not pushed to renderBuffer, wait for next render event
       if ( callbackPulled && !callbackPushed ) {
         WaitForSingleObject( renderEvent, INFINITE );
+        
+        if (stream_.state == STREAM_STOPPING) {
+          break;
+        }
       }
 
       // Get render buffer from stream

--- a/labsound/third_party/rtaudio/src/RtAudio.cpp
+++ b/labsound/third_party/rtaudio/src/RtAudio.cpp
@@ -4352,29 +4352,29 @@ void RtApiWasapi::stopStream( void )
 
   // stop capture client if applicable
   if ( ( ( WasapiHandle* ) stream_.apiHandle )->captureAudioClient ) {
-    HRESULT hr = ( ( WasapiHandle* ) stream_.apiHandle )->captureAudioClient->Stop();
-    if ( FAILED( hr ) ) {
+    /* HRESULT hr = */( ( WasapiHandle* ) stream_.apiHandle )->captureAudioClient->Stop();
+    /* if ( FAILED( hr ) ) {
       errorText_ = "RtApiWasapi::stopStream: Unable to stop capture stream.";
       error( RtAudioError::DRIVER_ERROR );
       return;
-    }
+    } */
   }
 
   // stop render client if applicable
   if ( ( ( WasapiHandle* ) stream_.apiHandle )->renderAudioClient ) {
-    HRESULT hr = ( ( WasapiHandle* ) stream_.apiHandle )->renderAudioClient->Stop();
-    if ( FAILED( hr ) ) {
+    /* HRESULT hr = */( ( WasapiHandle* ) stream_.apiHandle )->renderAudioClient->Stop();
+    /* if ( FAILED( hr ) ) {
       errorText_ = "RtApiWasapi::stopStream: Unable to stop render stream.";
       error( RtAudioError::DRIVER_ERROR );
       return;
-    }
+    } */
   }
 
   // close thread handle
   if ( stream_.callbackInfo.thread && !CloseHandle( ( void* ) stream_.callbackInfo.thread ) ) {
-    errorText_ = "RtApiWasapi::stopStream: Unable to close callback thread.";
+    /* errorText_ = "RtApiWasapi::stopStream: Unable to close callback thread.";
     error( RtAudioError::THREAD_ERROR );
-    return;
+    return; */
   }
 
   stream_.callbackInfo.thread = (ThreadHandle) NULL;


### PR DESCRIPTION
Needed for https://github.com/webmixedreality/exokit/issues/537.

- Add `AudioContext` `suspend`/`resume` methods
- Re-enable `RtAudio` stream stop/destruction
- Bugfix windows `RtAudio` destruction hang