### PR TITLE
Make AudioContext graph thread termination immediate

### DIFF
--- a/labsound/src/core/AudioContext.cpp
+++ b/labsound/src/core/AudioContext.cpp
@@ -206,7 +206,8 @@ void AudioContext::update()
     const float graphTickDurationMs = frameSizeMs * 16; // = ~5.5ms
     const int graphTickDurationUs = graphTickDurationMs * 1000.f;  // = ~5550us
 
-    while (updateThreadShouldRun || graphKeepAlive > 0)
+    // while (updateThreadShouldRun || graphKeepAlive > 0)
+    while (updateThreadShouldRun)
     {
         // A `unique_lock` automatically acquires a lock on construction. The purpose of
         // this mutex is to synchronize updates to the graph from the main thread, 


### PR DESCRIPTION
If there is a `ScriptProcessorNode` in the audio render graph, audio context destruction does not return.

After analysis this is the result of context destruction is:

- waiting for the context to finish rendering requires joining the Labsound audio graph thread
- the audio graph thread has a tail time to account for flushing existing buffers, and waits for enough sample time to pass through the render thread
- time only passes in the render thread while rendering happens
- if there is a ScriptProcessorNode in the render chain, that requires calling back to the main thread to execute the user logic
- we cannot call back to the main thread because the main thread is waiting for the context to finish rendering in the first place
- this is a deadlock

This PR fixes the issue by making audio context destruction immediate on request.