### PR TITLE
SampledAudioNode guard condition

### DIFF
--- a/labsound/src/core/SampledAudioNode.cpp
+++ b/labsound/src/core/SampledAudioNode.cpp
@@ -351,7 +351,9 @@ unsigned SampledAudioNode::numberOfChannels(ContextRenderLock& r)
 }
 
 void SampledAudioNode::setCurrentTime(double currentTime) {
-    m_virtualReadIndex = AudioUtilities::timeToSampleFrame(currentTime, m_sourceBus->sampleRate());
+    if (m_sourceBus) {
+        m_virtualReadIndex = AudioUtilities::timeToSampleFrame(currentTime, m_sourceBus->sampleRate());
+    }
 }
 
 void SampledAudioNode::startGrain(double when, double grainOffset)


### PR DESCRIPTION
This `m_sourceBus` check was missing.

Without it, a null `m_sourceBus`, which is the default, would cause a crash on setting the sampled node time.