### PR TITLE
Bugfix RealtimeAnalyzer memory corruption during setFftSize

### DIFF
--- a/labsound/include/LabSound/extended/RealtimeAnalyser.h
+++ b/labsound/include/LabSound/extended/RealtimeAnalyser.h
@@ -23,11 +23,11 @@ class RealtimeAnalyser
 public:
     RealtimeAnalyser(uint32_t fftSize);
     virtual ~RealtimeAnalyser();
-    RealtimeAnalyser &operator=(RealtimeAnalyser &&realtimeAnalyser);
     
     void reset();
 
     uint32_t fftSize() const { return m_fftSize; }
+    void setFftSize(uint32_t fftSize);
 
     uint32_t frequencyBinCount() const { return m_fftSize / 2; }
 

--- a/labsound/src/core/AnalyserNode.cpp
+++ b/labsound/src/core/AnalyserNode.cpp
@@ -50,7 +50,7 @@ void AnalyserNode::reset(ContextRenderLock&)
 
 void AnalyserNode::setFFTSize(ContextRenderLock& r, size_t fftSize)
 {
-  m_analyser = RealtimeAnalyser(fftSize);
+  m_analyser.setFftSize(fftSize);
 }
     
 } // namespace lab

--- a/labsound/src/core/RealtimeAnalyser.cpp
+++ b/labsound/src/core/RealtimeAnalyser.cpp
@@ -81,13 +81,23 @@ RealtimeAnalyser::~RealtimeAnalyser()
 
 }
 
-RealtimeAnalyser& RealtimeAnalyser::operator=(RealtimeAnalyser &&other) = default;
-
 void RealtimeAnalyser::reset()
 {
     m_writeIndex = 0;
     m_inputBuffer.zero();
     m_magnitudeBuffer.zero();
+}
+
+void RealtimeAnalyser::setFftSize(uint32_t fftSize) {
+  m_writeIndex = 0;
+
+  uint32_t size = max(min(RoundNextPow2(fftSize), MaxFFTSize), MinFFTSize);
+  m_fftSize = size;
+
+  m_analysisFrame = std::unique_ptr<FFTFrame>(new FFTFrame(size));
+
+  m_inputBuffer.zero();
+  m_magnitudeBuffer.allocate(size / 2);
 }
 
 void RealtimeAnalyser::writeInput(ContextRenderLock &r, AudioBus* bus, size_t framesToProcess)


### PR DESCRIPTION
[This line](https://github.com/modulesio/LabSound/compare/master...modulesio:realtime-fft?expand=1#diff-f0c3b186982e39fdecda11989bbae684L53) was causing a deallocation of live memory, causing crashes when AnalyzerNode was used.